### PR TITLE
Fixed decrement / accumulator addition

### DIFF
--- a/menorah_03.c
+++ b/menorah_03.c
@@ -353,7 +353,7 @@ void tune_playnote (byte chan, byte note) {
     if (chan < NUM_CHANS) {
         if (note>MAX_NOTE) note=MAX_NOTE;
         decrement[chan] = pgm_read_dword(decrement_PGM + note);
-        accumulator[chan] = ACCUM_RESTART;
+        accumulator[chan] += ACCUM_RESTART; // changed from '=' to '+=' for better frequency accuracy
         playing[chan]=true;
     }
 }


### PR DESCRIPTION
This fixes an issue where the accumulator throws out division remainders leading to "frequency stepping" in higher frequencies. The code now matches the comment block showing pseudocode for this function.
